### PR TITLE
Remove boolean operators from query

### DIFF
--- a/src/TermBuilder.php
+++ b/src/TermBuilder.php
@@ -6,6 +6,10 @@ class TermBuilder {
     public static function terms($search){
         $wildcards = config('laravel-fulltext.enable_wildcards');
 
+        // Remove every boolean operator (+, -, > <, ( ), ~, *, ", @distance) from the search query
+        // else we will break the MySQL query.
+        $search = preg_replace('/[+\-><\(\)~*\"@]+/', ' ', $search);
+
         $terms = collect(preg_split('/[\s,]+/', $search));
 
         if($wildcards === true){


### PR DESCRIPTION
We need tot remove the boolean operators from the search query, else the MySQL query will break.

E.g. beheer- en onderhoudsplan currently breaks the package.