### PR TITLE
Remove space character from the replace function

### DIFF
--- a/src/TermBuilder.php
+++ b/src/TermBuilder.php
@@ -8,7 +8,7 @@ class TermBuilder {
 
         // Remove every boolean operator (+, -, > <, ( ), ~, *, ", @distance) from the search query
         // else we will break the MySQL query.
-        $search = preg_replace('/[+\-><\(\)~*\"@]+/', ' ', $search);
+        $search = preg_replace('/[+\-><\(\)~*\"@]+/', '', $search);
 
         $terms = collect(preg_split('/[\s,]+/', $search));
 

--- a/src/TermBuilder.php
+++ b/src/TermBuilder.php
@@ -8,7 +8,7 @@ class TermBuilder {
 
         // Remove every boolean operator (+, -, > <, ( ), ~, *, ", @distance) from the search query
         // else we will break the MySQL query.
-        $search = preg_replace('/[+\-><\(\)~*\"@]+/', '', $search);
+        $search = rtrim(preg_replace('/[+\-><\(\)~*\"@]+/', ' ', $search));
 
         $terms = collect(preg_split('/[\s,]+/', $search));
 


### PR DESCRIPTION
When searching for a search string ending in a special character, 2 terms were created. This resulted in an error. The pull request fixes this behaviour.