### PR TITLE
Fix updating a record twice in one session

### DIFF
--- a/src/IndexedRecord.php
+++ b/src/IndexedRecord.php
@@ -12,6 +12,7 @@ class IndexedRecord extends Model {
     }
 
     public function updateIndex(){
+        $this->refresh();
         $this->setAttribute('indexed_title', $this->indexable->getIndexTitle());
         $this->setAttribute('indexed_content', $this->indexable->getIndexContent());
         $this->save();


### PR DESCRIPTION
When updating a record a second (or more) time(s) in the same session, the changes are not being saved to the fulltext search. It seems that the changes get cached the first time, and don't get updated on the fulltext model. Performing the refresh reloads the model from the DB. This will be slightly less efficient due to the DB access a second time, but it is probably worth the slight inefficiency to have expected behavior when updating your models.

Steps to replicate:
1. Open tinker
2. Update a model that uses Indexable
3. View record in fulltext DB table to verify record updated
4. In same tinker session make another update to same model record
5. View record in DB again to verify that record did NOT update

Restarting tinker in between updates does not result in the inconsistency.