### PR TITLE
Correctly retrieve relationship items when relationship is single item

### DIFF
--- a/src/Indexable.php
+++ b/src/Indexable.php
@@ -1,8 +1,8 @@
 <?php
 namespace Swis\LaravelFulltext;
 
-use Swis\LaravelFulltext\ModelObserver;
-use Swis\LaravelFulltext\IndexedRecord;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * Class Indexable
@@ -77,6 +77,12 @@ trait Indexable {
         if(is_null($this->{$relation})){
             return '';
         }
+
+        $relationship = $this->{$relation}();
+        if ($relationship instanceof BelongsTo || $relationship instanceof HasOne) {
+            return $this->{$relation}->{$column};
+        }
+
         return $this->{$relation}->pluck($column)->implode(', ');
     }
 }


### PR DESCRIPTION
There was an issue when building the index from an relationship, which retrieved all entries instead of just one when we were using an `BelongsTo` or `HasOne` relationship.

This pull request fixes that problem.