### PR TITLE
Remove IN BOOLEAN MODE

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -32,13 +32,11 @@ class Search implements SearchInterface
      */
     public function searchQuery($search)
     {
-        $termsBool = '';
         $termsMatch = '';
 
         if ($search) {
             $terms = TermBuilder::terms($search);
 
-            $termsBool = '+'.$terms->implode(' +');
             $termsMatch = ''.$terms->implode(' ');
         }
 
@@ -46,7 +44,7 @@ class Search implements SearchInterface
         $contentWeight = str_replace(',', '.', (float)config('laravel-fulltext.weight.content', 1.0));
 
         $query = IndexedRecord::query()
-          ->whereRaw('MATCH (indexed_title, indexed_content) AGAINST (? IN BOOLEAN MODE)', [$termsBool])
+          ->whereRaw('MATCH (indexed_title, indexed_content) AGAINST (?)', [$termsMatch])
           ->orderByRaw(
               '(' .$titleWeight. ' * (MATCH (indexed_title) AGAINST (?)) +
               ' . $contentWeight. ' * (MATCH (indexed_title, indexed_content) AGAINST (?))


### PR DESCRIPTION
Removed IN BOOLEAN MODE, as it does not seem to add any features.

I like this package, have used it on several projects and also on https://github.com/WebDevEtc/BlogEtc

However, I've had a problem with some searches not showing any results. I had a play around, and it works if I remove the boolean mode parts of the query.

for example, if I change the (generated) SQL query from:
```
select * from `laravel_fulltext` where
MATCH (indexed_title, indexed_content) AGAINST ('+the +between  +difference ' IN BOOLEAN MODE)
order by (1.5 * (MATCH (indexed_title) AGAINST ('What is the difference between')) +
          1 * (MATCH (indexed_title, indexed_content) AGAINST ('What is the difference between')))  
DESC  limit 100
```


to
```
select * from `laravel_fulltext` where
MATCH (indexed_title, indexed_content) AGAINST ('the between  difference ')
order by (1.5 * (MATCH (indexed_title) AGAINST ('What is the difference between')) +
          1 * (MATCH (indexed_title, indexed_content) AGAINST ('What is the difference between')))  
DESC  limit 100
```

(the first query shows zero results, the second shows results, as it should as there is content in `indexed_title` with the exact text "what is the difference between something and something else". I don't really why know it wasn't working).

I did some digging in the source code, and as far as I can tell, it isn't possible for the user to add any boolean search queries, as in `TermBuilder::terms()` it will remove any boolean characters (such as `-` or `+`). 

So, I was wondering - why is the boolean mode stuff there (the `+` before each word, and the `IN BOOLEAN MODE`)? 

I thought that maybe it used to be possible to do boolean searches (such as `restaurant -pizza`, but then with this fix: https://github.com/swisnl/laravel-fulltext/pull/9 that functionality got removed, but the "IN BOOLEAN MODE" parts stayed? 

Anyway, I've removed the IN BOOLEAN MODE. Maybe there was some other reason that I missed, and it should stay. If that is the case, I'd be interested in the reason why.

I've attached a pull request.

## Description

Removed `$termsBool` and `IN BOOLEAN MODE`.
Tested on local machine and a production machine, it works fine.

## Motivation and context

See above 

## How has this been tested?

Tested, seems ok.

## Screenshots (if appropriate)

n/a

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes. - none added
- [ ] If my change requires a change to the documentation, I have updated it accordingly. - none required

