### PR TITLE
Remove leading spaces to prevent empty terms

### DIFF
--- a/src/TermBuilder.php
+++ b/src/TermBuilder.php
@@ -10,7 +10,7 @@ class TermBuilder
 
         // Remove every boolean operator (+, -, > <, ( ), ~, *, ", @distance) from the search query
         // else we will break the MySQL query.
-        $search = rtrim(preg_replace('/[+\-><\(\)~*\"@]+/', ' ', $search));
+        $search = trim(preg_replace('/[+\-><\(\)~*\"@]+/', ' ', $search));
 
         $terms = collect(preg_split('/[\s,]+/', $search));
 

--- a/tests/TermBuilderTest.php
+++ b/tests/TermBuilderTest.php
@@ -17,6 +17,18 @@ class TermBuilderTest extends AbstractTestCase
         $this->assertCount(0, $diff);
     }
 
+    public function test_termbuilder_does_not_build_empty_terms()
+    {
+        global $configReturn;
+        $configReturn = false;
+
+        $termsResult = ['<hi', 'im', 'a', 'few', 'terms>'];
+        $terms = TermBuilder::terms(implode(' ', $termsResult));
+        $termsResultWithoutSpecialChars = ['hi', 'im', 'a', 'few', 'terms'];
+        $diff = $terms->diff($termsResultWithoutSpecialChars);
+        $this->assertCount(0, $diff);
+    }
+
     public function test_termbuilder_builds_terms_array_with_wildcard()
     {
         global $configReturn;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I changed `rtrim` to `trim` to make sure the split does not create an empty entry.

## Motivation and context

When searching for something like `~foo bar` you get an SQL error, but when you search for `foo bar~` it is ok. It looks to me that the first should also work.

## How has this been tested?

Tested in a real life application.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
