### PR TITLE
Add support for morph maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased]
 
+### Added
+
+* Added support for morph maps.
+
 ### Changed
 
 * Dropped PHP <7.4 support.

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -13,7 +13,7 @@ class Indexer
 
     public function unIndexOneByClass($class, $id)
     {
-        $record = IndexedRecord::where('indexable_id', $id)->where('indexable_type', $class);
+        $record = IndexedRecord::where('indexable_id', $id)->where('indexable_type', (new $class())->getMorphClass());
         if ($record->exists) {
             $record->delete();
         }

--- a/src/Search.php
+++ b/src/Search.php
@@ -25,7 +25,7 @@ class Search implements SearchInterface
     public function runForClass($search, $class)
     {
         $query = $this->searchQuery($search);
-        $query->where('indexable_type', $class);
+        $query->where('indexable_type', (new $class())->getMorphClass());
 
         return $query->get();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR wil add support for morph maps.

## Motivation and context

If you've enabled morph maps, it is currently impossible to run the searcher for one model. Laravel inserts the morph type in the `indexable_type` column, but we currently query it with the FQCN.

## How has this been tested?

Tested in an application with morph maps enabled. Test coverage is pretty low at the moment, so I consider adding missing tests out of scope.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
